### PR TITLE
[ISSUE-28] Updated create promotion with missing request fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xendit-python"
-version = "0.1.0"
+version = "0.1.1"
 description = "Xendit REST API Client for Python - Card, Virtual Account, Invoice, Disbursement, Recurring Payments, Payout, EWallet, Balance, Retail Outlets Services https://xendit.github.io/apireference/"
 authors = ["Adyaksa Wisanggeni <adyaksa@xendit.co>"]
 license = "MIT"

--- a/xendit/models/creditcard/credit_card.py
+++ b/xendit/models/creditcard/credit_card.py
@@ -430,6 +430,8 @@ class CreditCard(BaseModel):
         discount_percent=None,
         discount_amount=None,
         currency=None,
+        max_discount_amount=None,
+        min_original_amount=None,
         x_idempotency_key=None,
         for_user_id=None,
         x_api_version=None,
@@ -447,6 +449,8 @@ class CreditCard(BaseModel):
           - **channel_code (str)
           - **discount_percent (float)
           - **discount_amount (float)
+          - **max_discount_amount (float)
+          - **min_original_amount (float)
           - **currency (str)
           - **x_idempotency_key (str)
           - **for_user_id (str)

--- a/xendit/models/creditcard/credit_card_promotion.py
+++ b/xendit/models/creditcard/credit_card_promotion.py
@@ -19,6 +19,8 @@ class CreditCardPromotion(BaseModel):
       - currency (str)
       - start_time (str)
       - end_time (str)
+      - min_original_amount (float)
+      - max_discount_amount (float)
     """
 
     id: str
@@ -34,3 +36,5 @@ class CreditCardPromotion(BaseModel):
     currency: str
     start_time: str
     end_time: str
+    min_original_amount: float
+    max_discount_amount: float


### PR DESCRIPTION
Added `min_original_amount` and `max_discount_amount` as per [Xendit's API documentation](https://developers.xendit.co/api-reference/?python#create-promotion).