### PR TITLE
Added customer_notifications_preference and expiry_date on invoice.py

### DIFF
--- a/xendit/models/invoice/invoice.py
+++ b/xendit/models/invoice/invoice.py
@@ -75,6 +75,8 @@ class Invoice(BaseModel):
         description,
         amount,
         customer=None,
+        customer_notification_preference=None,
+        expiry_date=None,
         should_send_email=None,
         callback_virtual_account_id=None,
         invoice_duration=None,


### PR DESCRIPTION
Error:
1. _request() got an unexpected keyword argument 'expiry_date'
2. _request() got an unexpected keyword argument 'customer_notifications_preference'

Fixing:
1. added customer_notification_preference=None on invoice.py
2. added expiry_date=None on invoice.py