### PR TITLE
[CC-6526] Add metadata field for credit card function

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ charge = CreditCard.create_authorization(
     external_id="card_preAuth-1594106356",
     amount=75000,
     card_cvn="123",
+    metadata={
+        "meta": "data",
+    },
 )
 print(charge)
 ```
@@ -282,7 +285,10 @@ Will return
     "bank_reconciliation_id": "5941063625146828103011",
     "approval_code": "831000",
     "created": "2020-07-07T07:19:22.921Z",
-    "id": "5f0421fa8cc1e8001973a1d6"
+    "id": "5f0421fa8cc1e8001973a1d6",
+    "metadata": {
+        "meta": "data"
+    }
 }
 ```
 
@@ -323,6 +329,9 @@ charge = CreditCard.create_charge(
     external_id="card_charge-1594106478",
     amount=75000,
     card_cvn="123",
+    metadata={
+        "meta": "data",
+    },
 )
 print(charge)
 ```
@@ -348,7 +357,10 @@ Will return
     "bank_reconciliation_id": "5941064846646923303008",
     "approval_code": "831000",
     "created": "2020-07-07T07:21:25.027Z",
-    "id": "5f0422752bbbe50019a368b5"
+    "id": "5f0422752bbbe50019a368b5",
+    "metadata": {
+        "meta": "data"
+    }
 }
 ```
 

--- a/tests/integration/test_credit_card.py
+++ b/tests/integration/test_credit_card.py
@@ -21,6 +21,9 @@ class TestCreditCard(BaseIntegrationTest):
             external_id=f"card_preAuth-{int(time.time())}",
             amount=75000,
             card_cvn="123",
+            metadata={
+                "meta": "data",
+            },
         )
 
         self.assert_returned_object_has_same_key_as_sample_response(
@@ -49,6 +52,9 @@ class TestCreditCard(BaseIntegrationTest):
             external_id=f"card_preAuth-{int(time.time())}",
             amount=75000,
             card_cvn="123",
+            metadata={
+                "meta": "data",
+            },
         )
 
         self.assert_returned_object_has_same_key_as_sample_response(

--- a/tests/integration/test_credit_card.py
+++ b/tests/integration/test_credit_card.py
@@ -36,6 +36,9 @@ class TestCreditCard(BaseIntegrationTest):
             external_id=f"card_preAuth-{int(time.time())}",
             amount=75000,
             card_cvn="123",
+            metadata={
+                "meta": "data",
+            },
         )
         reverse_auth = CreditCard.reverse_authorization(
             credit_card_charge_id=charge.id,

--- a/tests/sampleresponse/credit_card.py
+++ b/tests/sampleresponse/credit_card.py
@@ -1,7 +1,6 @@
 def reverse_auth_response():
     return {
         "status": "SUCCEEDED",
-        "currency": "IDR",
         "credit_card_charge_id": "5f0421fa8cc1e8001973a1d6",
         "business_id": "5ed75086a883856178afc12e",
         "external_id": "card_preAuth-1594106356",
@@ -32,7 +31,7 @@ def charge_response():
         "created": "2020-07-07T07:19:22.921Z",
         "id": "5f0421fa8cc1e8001973a1d6",
         "metadata": {
-            "meta": "data"
+            "meta": "data",
         },
     }
 

--- a/tests/sampleresponse/credit_card.py
+++ b/tests/sampleresponse/credit_card.py
@@ -31,6 +31,9 @@ def charge_response():
         "approval_code": "831000",
         "created": "2020-07-07T07:19:22.921Z",
         "id": "5f0421fa8cc1e8001973a1d6",
+        "metadata": {
+            "meta": "data"
+        },
     }
 
 

--- a/tests/unit/models/creditcard/test_create_authorization.py
+++ b/tests/unit/models/creditcard/test_create_authorization.py
@@ -19,6 +19,9 @@ class TestCreateAuthorization(ModelBaseTest):
             "amount": 75000,
             "card_cvn": "123",
             "x_idempotency_key": "test-idemp_123",
+            "metadata": {
+                "meta": "data",
+            },
         }
         params = (args, kwargs)
         url = "/credit_card_charges"
@@ -35,6 +38,9 @@ class TestCreateAuthorization(ModelBaseTest):
             "external_id": "mock_card_preAuth-123",
             "amount": 75000,
             "card_cvn": "123",
+            "metadata": {
+                "meta": "data",
+            },
         }
         return (tested_class, class_name, method_name, http_method_name, url, params, headers, body)
 

--- a/tests/unit/models/creditcard/test_create_charge.py
+++ b/tests/unit/models/creditcard/test_create_charge.py
@@ -34,6 +34,9 @@ class TestCreateCharge(ModelBaseTest):
             "billing_details": billing_details,
             "installment": installment,
             "promotion": promotion,
+            "metadata": {
+                "meta": "data",
+            },
         }
         params = (args, kwargs)
         url = "/credit_card_charges"
@@ -63,6 +66,9 @@ class TestCreateCharge(ModelBaseTest):
             "promotion": {
                 "reference_id": "Xendit-123",
                 "original_amount": 75000
+            },
+            "metadata": {
+                "meta": "data",
             },
         }
         return (tested_class, class_name, method_name, http_method_name, url, params, headers, body)

--- a/xendit/models/creditcard/credit_card.py
+++ b/xendit/models/creditcard/credit_card.py
@@ -160,6 +160,7 @@ class CreditCard(BaseModel):
         x_idempotency_key=None,
         for_user_id=None,
         x_api_version=None,
+        metadata=None,
         **kwargs,
     ):
         """Send POST Request to create Credit Card Authorization (API Reference: Credit Card/Create Authorization)
@@ -180,6 +181,7 @@ class CreditCard(BaseModel):
           - **x_idempotency_key (str)
           - **for_user_id (str)
           - **x_api_version (str)
+          - **metadata (dict)
 
 
         Returns:
@@ -255,6 +257,7 @@ class CreditCard(BaseModel):
         x_idempotency_key=None,
         for_user_id=None,
         x_api_version=None,
+        metadata=None,
         **kwargs,
     ):
         """Send POST Request to create Credit Card Charge (API Reference: Credit Card/Create Charge)
@@ -275,6 +278,7 @@ class CreditCard(BaseModel):
           - **x_idempotency_key (str)
           - **for_user_id (str)
           - **x_api_version (str)
+          - **metadata (dict)
 
         Returns:
           CreditCardCharge


### PR DESCRIPTION
## Description
Support metadata field on xendit-python library
- CreditCard.create_authorization
- CreditCard.create_charge 
https://developers.xendit.co/api-reference/#create-charge
