### PR TITLE
fix: incorrect import for EWallet class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xendit-python"
-version = "0.2.1"
+version = "0.2.2"
 description = "Xendit REST API Client for Python - Card, Virtual Account, Invoice, Disbursement, Recurring Payments, Payout, EWallet, Balance, Retail Outlets, Payments API, Services https://xendit.github.io/apireference/"
 authors = ["Maahir Ur Rahman <maahir@xendit.co>"]
 license = "MIT"

--- a/xendit/_xendit_param_injector.py
+++ b/xendit/_xendit_param_injector.py
@@ -8,7 +8,7 @@ from .models import CardlessCredit
 from .models import CreditCard
 from .models import DirectDebit
 from .models import Disbursement
-from .models import EWallet
+from .models.ewallet import EWallet
 from .models import Invoice
 from .models import PaymentMethod
 from .models import PaymentRequest


### PR DESCRIPTION
Fixes #64 and #60 caused by the Payments API EWallet class being instantiated instead of the original EWallet class